### PR TITLE
Show build errors when running dev-server

### DIFF
--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -155,7 +155,7 @@ const config: Configuration = {
 	},
 	devServer: {
 		hot: true,
-		stats: 'none',
+		stats: 'errors-only',
 		contentBase: 'public',
 		watchContentBase: true
 	},


### PR DESCRIPTION
`stats: none` won't even output build errors, so if there is a problem
that prevents the code from compiling, Webpack would just bluntly output
`"｢wdm｣: Failed to compile"` and nothing more. That's not terribly useful,
and I think most developers would rather see the error to be able to fix it.

Docs for the option:
https://webpack.js.org/configuration/dev-server/#devserverstats-