### PR TITLE
Support comments in TSConfig and fix for when module != "commonjs"

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
 		"postcss": "8.3",
 		"postcss-loader": "^5.0.0",
 		"regenerator-runtime": "^0.13.7",
+		"require-json5": "^1.1.0",
 		"sass": "^1.32.8",
 		"sass-loader": "^11.0.1",
 		"svelte": "^3.32.3",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,5 +22,9 @@
 			"svelte/animate",
 			"svelte/easing"
 		]
+	},
+	// see: https://github.com/webpack/webpack-cli/issues/2458#issuecomment-846635277
+	"ts-node": {
+		"compilerOptions": { "module": "commonjs" }
 	}
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,4 +1,5 @@
 {
+	// TSConfig file.
 	"include": ["src/**/*", "webpack.config.ts"],
 	"exclude": ["node_modules/*", "__sapper__/*", "public/*"],
 	"compilerOptions": {

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -216,6 +216,9 @@ if (isProduction) {
 	config.optimization.minimize = true;
 }
 
+// Parse as JSON5 to add support for comments in tsconfig.json parsing.
+require('require-json5').replace();
+
 // Load path aliases from the tsconfig.json file
 const tsconfigPath = path.resolve(__dirname, 'tsconfig.json');
 const tsconfig = fs.existsSync(tsconfigPath) ? require(tsconfigPath) : {};


### PR DESCRIPTION
Typescript support comments natively in tsconfig.json, but we get errors here, I have used json5 to require tsconfig file, which allows to load it with comments. 

Also, related the issue: https://github.com/webpack/webpack-cli/issues/2458#issuecomment-846635277
added the workaround for using `import` in `webpack.config.ts` when `module` is `ES20xx` in tsconfig.json