### PR TITLE
Update packages and fix vulnerabilities, add svelte-check during build step

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
 		"sass-loader": "^11.0.1",
 		"svelte": "^3.32.3",
 		"svelte-check": "^1.1.35",
-		"svelte-check-plugin": "^1.0.1",
+		"svelte-check-plugin": "zachmatson/svelte-check-plugin#fix-windows",
 		"svelte-loader": "^3.0.0",
 		"svelte-preprocess": "^4.6.9",
 		"ts-loader": "^8.0.17",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
 		"sass-loader": "^11.0.1",
 		"svelte": "^3.32.3",
 		"svelte-check": "^1.1.35",
-		"svelte-check-plugin": "zachmatson/svelte-check-plugin#fix-windows",
+		"svelte-check-plugin": "^1.0.2",
 		"svelte-loader": "^3.0.0",
 		"svelte-preprocess": "^4.6.9",
 		"ts-loader": "^8.0.17",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
 		"sass-loader": "^11.0.1",
 		"svelte": "^3.32.3",
 		"svelte-check": "^1.1.35",
+		"svelte-check-plugin": "^1.0.0",
 		"svelte-loader": "^3.0.0",
 		"svelte-preprocess": "^4.6.9",
 		"ts-loader": "^8.0.17",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
 		"sass-loader": "^11.0.1",
 		"svelte": "^3.32.3",
 		"svelte-check": "^1.1.35",
-		"svelte-check-plugin": "^1.0.0",
+		"svelte-check-plugin": "^1.0.1",
 		"svelte-loader": "^3.0.0",
 		"svelte-preprocess": "^4.6.9",
 		"ts-loader": "^8.0.17",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
 		"@babel/plugin-transform-runtime": "^7.12.17",
 		"@babel/preset-env": "^7.12.17",
 		"@babel/runtime": "^7.12.18",
-		"@types/css-minimizer-webpack-plugin": "^1.3.0",
 		"@types/mini-css-extract-plugin": "^1.2.2",
 		"@types/webpack-dev-server": "^3.11.1",
 		"autoprefixer": "^10.2.4",
@@ -37,10 +36,10 @@
 		"typescript": "^4.1.5",
 		"webpack": "^5.23.0",
 		"webpack-cli": "^4.5.0",
-		"webpack-dev-server": "^3.11.2"
+		"webpack-dev-server": "^4.7.3"
 	},
 	"dependencies": {
-		"serve": "^11.3.2"
+		"serve": "^13.0.2"
 	},
 	"browserslist": [
 		"defaults"

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -28,6 +28,12 @@ const stylesheets = [
  */
 const sourceMapsInProduction = false;
 
+/**
+ * This option will run svelte-check when the bundle is built, and cause the build to fail when svelte-check
+ * has errors or warnings
+ */
+const svelteCheckOnBuild = true;
+
 /*********************************************************************************************************************/
 /**********                                             Webpack                                             **********/
 /*********************************************************************************************************************/
@@ -38,6 +44,7 @@ import SveltePreprocess from 'svelte-preprocess';
 import Autoprefixer from 'autoprefixer';
 import MiniCssExtractPlugin from 'mini-css-extract-plugin';
 import CSSMinimizerPlugin from 'css-minimizer-webpack-plugin';
+import SvelteCheckPlugin from 'svelte-check-plugin';
 
 import { CleanWebpackPlugin } from 'clean-webpack-plugin';
 
@@ -160,7 +167,8 @@ const config: Configuration = {
 	plugins: [
 		new MiniCssExtractPlugin({
 			filename: '[name].css'
-		})
+		}),
+		...(svelteCheckOnBuild ? [new SvelteCheckPlugin()] : [])
 	],
 	devtool: isProduction && !sourceMapsInProduction ? false : 'source-map',
 	stats: {

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -32,7 +32,12 @@ const sourceMapsInProduction = false;
  * This option will run svelte-check when the bundle is built, and cause the build to fail when svelte-check
  * has errors or warnings
  */
-const svelteCheckOnBuild = true;
+const svelteCheckOnBuild = false;
+/**
+ * This option will run svelte-check when the bundle is built in production mode only, and cause the build to fail
+ * when svelte-check has errors or warnings
+ */
+const svelteCheckOnBuildInProduction = true;
 
 /*********************************************************************************************************************/
 /**********                                             Webpack                                             **********/
@@ -168,7 +173,7 @@ const config: Configuration = {
 		new MiniCssExtractPlugin({
 			filename: '[name].css'
 		}),
-		...(svelteCheckOnBuild ? [new SvelteCheckPlugin()] : [])
+		...(svelteCheckOnBuild || isProduction && svelteCheckOnBuildInProduction ? [new SvelteCheckPlugin()] : [])
 	],
 	devtool: isProduction && !sourceMapsInProduction ? false : 'source-map',
 	stats: {

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -155,9 +155,6 @@ const config: Configuration = {
 	},
 	devServer: {
 		hot: true,
-		stats: 'errors-only',
-		contentBase: 'public',
-		watchContentBase: true
 	},
 	target: isDevelopment ? 'web' : 'browserslist',
 	plugins: [


### PR DESCRIPTION
This fixes package vulnerabilities (`npm fix --force`), updates npm packages (`npm update`), and adds `svelte-check` as a plugin in the build process by default, to cause build errors when `svelte-check` has errors or warnings. This last option also has a flag so that it can be disabled. `svelte-check` during the build process completes TypeScript support in a way by actually verifying types as the site is being developed. Something like ForkTsWebpackPlugin could also be added to verify types for non-`.svelte` files too potentially.